### PR TITLE
run gofmtcheck earlier

### DIFF
--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -24,6 +24,9 @@ jobs:
       - name: make tools
         run: |
           make tools
+      - name: gofmtcheck
+        run: |
+          make gofmtcheck
       - name: gencheck
         run: |
           make gencheck
@@ -33,9 +36,6 @@ jobs:
       - name: tffmtcheck
         run: |
           make tffmtcheck
-      - name: gofmtcheck
-        run: |
-          make gofmtcheck
       - name: terrafmtcheck
         run: |
           make terrafmtcheck


### PR DESCRIPTION
running gofmtcheck after tfvalidatecheck has the side effect
that golang code present in referenced terraform modules is also
checked in the CI. We should check golang code only coming from
this repo and not from the terraform modules downloaded from other
repositories.

Fixes #006



