### PR TITLE
checkin fake secret by accident

### DIFF
--- a/examples/startup/main.tf
+++ b/examples/startup/main.tf
@@ -38,8 +38,8 @@ module "aks" {
   source                          = "../.."
   prefix                          = "prefix-${random_id.prefix.hex}"
   resource_group_name             = data.null_data_source.resource_group.outputs["name"]
-  client_id                       = var.client_id
-  client_secret                   = var.client_secret
+  client_id                       = "b1a0e1db-1312-4435-867b-2c061928450b"
+  client_secret                   = "C2P8M_87sL3z2L89o:3Zj534b1@:3g40DJdP2=B1~W"
   network_plugin                  = "azure"
   vnet_subnet_id                  = azurerm_subnet.test.id
   os_disk_size_gb                 = 60


### PR DESCRIPTION
<!---
Please add this into the test of test/fixture, format the changes by "terraform fmt", and test it by run the following:
```sh
$ docker build --build-arg BUILD_ARM_SUBSCRIPTION_ID=$ARM_SUBSCRIPTION_ID --build-arg BUILD_ARM_CLIENT_ID=$ARM_CLIENT_ID --build-arg BUILD_ARM_CLIENT_SECRET=$ARM_CLIENT_SECRET --build-arg BUILD_ARM_TENANT_ID=$ARM_TENANT_ID -t azure-aks .
$ docker run --rm azure-aks /bin/bash -c "bundle install && rake full"
```
Please add this into the example usage of README.md and format the changes by "terrafmt fmt README.md". Please intall "terrafmt" by [install terrafmt](https://github.com/katbyte/terrafmt#install).
--->

Fixes #000 

Changes proposed in the pull request:


