### PR TITLE
Fix to run goimport-file.sh that does not have exec permission

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -64,7 +64,7 @@ terrafmt:
 
 goimports:
 	@echo "==> Fixing imports code with goimports..."
-	@find . -name '*.go' | grep -v vendor | while read f; do ./scripts/goimport-file.sh "$$f"; done
+	@find . -name '*.go' | grep -v vendor | while read f; do bash ./scripts/goimport-file.sh "$$f"; done
 
 pre-commit: tffmt terrafmt goimports fmt fumpt generate
 


### PR DESCRIPTION
Using `bash` in front of the script we want to execute solves the problem that the file is not executable.
Otherwise it fails like:

```
==> Fixing imports code with goimports...
/bin/sh: 1: ./scripts/goimport-file.sh: Permission denied
make: *** [GNUmakefile:67: goimports] Error 126
```


